### PR TITLE
Add secure cookie headers

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -57,3 +57,8 @@ func (gs *Gosesh) parseIdentifierFromCookie(r *http.Request) (Identifier, error)
 
 	return gs.identifierFromBytes(sessionIDRaw)
 }
+
+func setSecureCookieHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", `private, no-cache="Set-Cookie"`)
+	w.Header().Set("Vary", "Cookie")
+}

--- a/handlers.go
+++ b/handlers.go
@@ -15,6 +15,8 @@ import (
 
 func (gs *Gosesh) OAuth2Begin(oauthCfg *oauth2.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		setSecureCookieHeaders(w)
+
 		b := make([]byte, 16)
 		if _, err := rand.Read(b); err != nil {
 			gs.logError("failed to create OAuth2 state", err)
@@ -52,6 +54,8 @@ func (gs *Gosesh) OAuth2Callback(user OAuth2User, config *oauth2.Config, done Ha
 		done = defaultDoneHandler(gs, "OAuth2Callback")
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
+		setSecureCookieHeaders(w)
+
 		ctx := r.Context()
 		oauthState, err := r.Cookie(gs.oAuth2StateCookieName)
 		if err != nil {

--- a/middleware.go
+++ b/middleware.go
@@ -88,6 +88,8 @@ func (gs *Gosesh) authenticate(w http.ResponseWriter, r *http.Request) *http.Req
 		return r
 	}
 
+	setSecureCookieHeaders(w)
+
 	ctx := r.Context()
 
 	id, err := gs.parseIdentifierFromCookie(r)


### PR DESCRIPTION
Adds headers to guard against caching responses in a way that could result in responses or cookies being shared.